### PR TITLE
Avoid stack overflow on decode

### DIFF
--- a/src/main/TextDecoder.ts
+++ b/src/main/TextDecoder.ts
@@ -107,6 +107,10 @@ export class TextDecoder implements globalThis.TextDecoder {
         }
 
         // Create and return string from decoded code points
-        return String.fromCodePoint(...output);
+        let text = '';
+        for (const codePoint of output) {
+            text += String.fromCodePoint(codePoint);
+        }
+        return text;
     }
 }


### PR DESCRIPTION
This PR includes changes that will avoid a stack overflow when the decoder receives a large array buffer.

- Closes https://github.com/kayahr/text-encoding/issues/2